### PR TITLE
[hotfix]: Improving post page layout

### DIFF
--- a/src/pages/layout-verify/index.astro
+++ b/src/pages/layout-verify/index.astro
@@ -13,6 +13,9 @@ import PostLayout from '../../layouts/PostLayout.astro';
   <p>
     Paragraph with inline <code class="language-text">code</code> and a Prism sample below.
   </p>
+  <p>
+    Classless inline code: <code>~60-120s</code> build time and route <code>/en/</code>.
+  </p>
   <div class="blog-code-frame">
     <pre class="language-ts"
       ><code class="language-ts"
@@ -20,6 +23,22 @@ import PostLayout from '../../layouts/PostLayout.astro';
       ></pre
     >
   </div>
+  <pre class="language-js" data-language="js"><code class="language-js"><span class="token comment">// bare block — no .blog-code-frame wrapper, mirrors real Markdown output</span>
+<span class="token keyword">const</span> migrated <span class="token operator">=</span> <span class="token boolean">true</span><span class="token punctuation">;</span></code></pre>
+  <ul>
+    <li>Unordered item one</li>
+    <li>Unordered item two
+      <ul>
+        <li>Nested circle item</li>
+      </ul>
+    </li>
+    <li>Unordered item three</li>
+  </ul>
+  <ol>
+    <li>Ordered item one</li>
+    <li>Ordered item two</li>
+    <li>Ordered item three</li>
+  </ol>
   <p>
     <img
       src="https://astro.build/favicon.svg"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -87,7 +87,8 @@ pre[class*='language-'] ::selection {
   background: hsla(0, 0%, 100%, 0.15);
 }
 
-:not(pre) > code[class*='language-'] {
+:not(pre) > code[class*='language-'],
+.markdown-body :not(pre) > code {
   border-radius: 0.3em;
   background: var(--blog-inline-code-bg);
   color: var(--blog-inline-code-text);
@@ -335,6 +336,27 @@ pre[data-line] {
 .markdown-body ul,
 .markdown-body ol {
   margin-left: 1.75rem;
+  padding-left: 0.25rem;
+}
+
+.markdown-body ul {
+  list-style-type: disc;
+}
+
+.markdown-body ul ul {
+  list-style-type: circle;
+}
+
+.markdown-body ul ul ul {
+  list-style-type: square;
+}
+
+.markdown-body ol {
+  list-style-type: decimal;
+}
+
+.markdown-body ol ol {
+  list-style-type: lower-alpha;
 }
 
 .markdown-body li > * + * {
@@ -371,4 +393,28 @@ pre[data-line] {
 
 .markdown-body pre:not(:last-child) {
   margin-bottom: 1.75rem;
+}
+
+/* Bare fenced-code blocks from Markdown (no .blog-code-frame wrapper). */
+.markdown-body pre[class*='language-'] {
+  background: var(--blog-code-bg);
+  border-radius: 10px;
+  margin-left: -1.3125rem;
+  margin-right: -1.3125rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 672px) {
+  .markdown-body pre[class*='language-'] {
+    border-radius: 0;
+  }
+}
+
+/* When .blog-code-frame wraps the pre, the frame div already provides the card surface;
+   undo the markdown-body overrides to avoid double background and stacked negative margins. */
+.blog-code-frame pre[class*='language-'] {
+  background: none;
+  border-radius: 0;
+  margin-left: 0;
+  margin-right: 0;
 }


### PR DESCRIPTION
## Summary
- Added new inline code examples and a list structure to the layout-verify page for improved content presentation.
- Updated global CSS to enhance styling for unordered and ordered lists, including nested list types.
- Introduced styles for bare fenced-code blocks to better reflect Markdown output without additional wrappers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to post/markdown rendering (lists and code blocks) with low functional risk, but may affect visual layout across all posts using `.markdown-body`.
> 
> **Overview**
> Improves post Markdown layout by styling *classless* inline `code` inside `.markdown-body`, so Markdown-rendered inline code matches Prism-styled snippets.
> 
> Updates list spacing and explicitly sets bullet/number styles for nested `.markdown-body` `ul`/`ol` to make hierarchy clearer.
> 
> Adds dedicated styling for **bare fenced code blocks** (`.markdown-body pre[class*='language-']`) and cancels those overrides when `pre` is wrapped by `.blog-code-frame` to avoid double backgrounds/margins; `layout-verify` fixture is expanded to cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e884de4699fdcefb7d4ed54a8acb0f063c3695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->